### PR TITLE
Resolve XML import error with decimal items

### DIFF
--- a/dcs-dtc/Models/AH64/AH64Configuration.cs
+++ b/dcs-dtc/Models/AH64/AH64Configuration.cs
@@ -99,10 +99,10 @@ namespace DTC.Models.AH64
 
                 var lat = pos.Element("Latitude")?.Value;
                 var lon = pos.Element("Longitude")?.Value;
-                var dLat = double.Parse(lat.Replace('.', ','));
-                var dLon = double.Parse(lon.Replace('.', ','));
+                var dLat = double.Parse(lat.Replace(',', '.'));
+                var dLon = double.Parse(lon.Replace(',', '.'));
 
-                float.TryParse(pos.Element("Altitude")?.Value.Replace('.', ','), out var elevation);
+                float.TryParse(pos.Element("Altitude")?.Value.Replace(',', '.'), out var elevation);
                 var coord = new Coordinate(dLat, dLon);
                 lat = $"{(dLat > 0 ? 'N' : 'S')} {coord.Latitude.Degrees:00}.{coord.Latitude.DecimalMinute:00.000}";
                 lon = $"{(dLon > 0 ? 'E' : 'W')} {Math.Abs(coord.Longitude.Degrees):000}.{coord.Longitude.DecimalMinute:00.000}";

--- a/dcs-dtc/Models/AH64/Upload/WaypointBuilder.cs
+++ b/dcs-dtc/Models/AH64/Upload/WaypointBuilder.cs
@@ -70,7 +70,10 @@ namespace DTC.Models.AH64.Upload
                 AppendCommand(ClearKU(ku));
                 AppendCommand(BuildInputString(ku, wpt.Mgrs));
                 AppendCommand(ku.GetCommand("ENTR"));
-                AppendCommand(BuildInputString(ku, wpt.Elevation.ToString()));
+                if (wpt.Elevation != 0)
+                {
+                    AppendCommand(BuildInputString(ku, wpt.Elevation.ToString()));
+                }
                 AppendCommand(ku.GetCommand("ENTR"));
                 AppendCommand(mpd.GetCommand("TSD"));
             }

--- a/dcs-dtc/Models/F16/F16Configuration.cs
+++ b/dcs-dtc/Models/F16/F16Configuration.cs
@@ -140,10 +140,10 @@ namespace DTC.Models.F16
 
                 var lat = pos.Element("Latitude")?.Value;
                 var lon = pos.Element("Longitude")?.Value;
-                var dLat = double.Parse(lat.Replace('.', ','));
-                var dLon = double.Parse(lon.Replace('.', ','));
+                var dLat = double.Parse(lat.Replace(',', '.'));
+                var dLon = double.Parse(lon.Replace(',', '.'));
 
-                float.TryParse(pos.Element("Altitude")?.Value.Replace('.', ','), out var elevation);
+                float.TryParse(pos.Element("Altitude")?.Value.Replace(',', '.'), out var elevation);
                 var coord = new Coordinate(dLat, dLon);
                 lat = $"{(dLat > 0 ? 'N' : 'S')} {coord.Latitude.Degrees:00}.{coord.Latitude.DecimalMinute:00.000}";
                 lon = $"{(dLon > 0 ? 'E' : 'W')} {Math.Abs(coord.Longitude.Degrees):000}.{coord.Longitude.DecimalMinute:00.000}";

--- a/dcs-dtc/Models/FA18/FA18Configuration.cs
+++ b/dcs-dtc/Models/FA18/FA18Configuration.cs
@@ -129,9 +129,9 @@ namespace DTC.Models.FA18
 
                 var lat = pos.Element("Latitude")?.Value;
                 var lon = pos.Element("Longitude")?.Value;
-                var dLat = double.Parse(lat.Replace('.', ','));
-                var dLon = double.Parse(lon.Replace('.', ','));
-                float.TryParse(pos.Element("Altitude")?.Value.Replace('.', ','), out var elevation);
+                var dLat = double.Parse(lat.Replace(',', '.'));
+                var dLon = double.Parse(lon.Replace(',', '.'));
+                float.TryParse(pos.Element("Altitude")?.Value.Replace(',', '.'), out var elevation);
                 var coord = new Coordinate(dLat, dLon);
                 lat = $"{(dLat > 0 ? 'N' : 'S')} {coord.Latitude.Degrees:00}.{coord.Latitude.DecimalMinute:00.000}";
                 lon = $"{(dLon > 0 ? 'E' : 'W')} {Math.Abs(coord.Longitude.Degrees):000}.{coord.Longitude.DecimalMinute:00.000}";

--- a/dcs-dtc/UI/Aircrafts/AH64/WaypointEdit.cs
+++ b/dcs-dtc/UI/Aircrafts/AH64/WaypointEdit.cs
@@ -159,7 +159,7 @@ namespace DTC.UI.Aircrafts.AH64
 
         private bool ValidateElevation()
         {
-            if (!Util.IsValidInt(txtWptElevation.Text))
+            if (!Util.IsValidInt(txtWptElevation.Text) && txtWptType.Text != "")
             {
                 lblValidation.Text = "Invalid elevation";
                 txtWptElevation.Focus();

--- a/dcs-dtc/UI/Aircrafts/AH64/WaypointEdit.cs
+++ b/dcs-dtc/UI/Aircrafts/AH64/WaypointEdit.cs
@@ -159,7 +159,7 @@ namespace DTC.UI.Aircrafts.AH64
 
         private bool ValidateElevation()
         {
-            if (!Util.IsValidInt(txtWptElevation.Text) && txtWptType.Text != "")
+            if (!Util.IsValidInt(txtWptElevation.Text))
             {
                 lblValidation.Text = "Invalid elevation";
                 txtWptElevation.Focus();


### PR DESCRIPTION
Ensure the XML import parses decimal entries correctly and resolves "Cannot be greater than 90 degrees" error when importing decimal latitudes